### PR TITLE
fix(AMI-84): production-ready receipt-to-invoice extraction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,9 @@ npm-debug.log
 # Hermes agent state
 .hermes/
 
+# Ouroboros local state
+.ouroboros/
+
 # Environment
 .env
 .env.*

--- a/lib/auto_my_invoice/ai/vision_client.ex
+++ b/lib/auto_my_invoice/ai/vision_client.ex
@@ -116,7 +116,9 @@ defmodule AutoMyInvoice.AI.VisionClient do
   defp media_type("png"), do: "image/png"
   defp media_type(_), do: "application/octet-stream"
 
-  defp parse_response(%{"choices" => [%{"message" => %{"content" => content}} | _]} = raw) do
+  @doc false
+  # Exposed for unit testing. Not part of the public API surface.
+  def parse_response(%{"choices" => [%{"message" => %{"content" => content}} | _]} = raw) do
     cleaned = content |> String.trim() |> strip_markdown_fences()
 
     case Jason.decode(cleaned) do
@@ -130,18 +132,20 @@ defmodule AutoMyInvoice.AI.VisionClient do
     end
   end
 
-  defp parse_response(raw) do
+  def parse_response(raw) do
     {:error, "Unexpected API response format: #{inspect(raw) |> String.slice(0..200)}"}
   end
 
-  defp strip_markdown_fences(text) do
+  @doc false
+  def strip_markdown_fences(text) do
     text
     |> String.replace(~r/^```json\s*/i, "")
     |> String.replace(~r/\s*```$/, "")
   end
 
-  defp parse_confidence(nil), do: 0.5
-  defp parse_confidence(c) when is_float(c), do: min(max(c, 0.0), 1.0)
-  defp parse_confidence(c) when is_integer(c), do: min(max(c / 1.0, 0.0), 1.0)
-  defp parse_confidence(_), do: 0.5
+  @doc false
+  def parse_confidence(nil), do: 0.5
+  def parse_confidence(c) when is_float(c), do: min(max(c, 0.0), 1.0)
+  def parse_confidence(c) when is_integer(c), do: min(max(c / 1.0, 0.0), 1.0)
+  def parse_confidence(_), do: 0.5
 end

--- a/lib/auto_my_invoice_web/live/invoice_live/new.ex
+++ b/lib/auto_my_invoice_web/live/invoice_live/new.ex
@@ -9,7 +9,12 @@ defmodule AutoMyInvoiceWeb.InvoiceLive.New do
           job = AutoMyInvoice.Extraction.get_job!(job_id)
 
           if job.status == "completed" do
-            AutoMyInvoice.Extraction.to_invoice_attrs(job)
+            # Extraction.to_invoice_attrs/1 expects the string-keyed
+            # `extracted_data` map produced by the AI client — NOT the
+            # ExtractionJob struct itself. Passing the struct here would
+            # cause Access.get/3 to raise on Elixir 1.19+ because Ecto
+            # schemas do not implement the Access behaviour.
+            AutoMyInvoice.Extraction.to_invoice_attrs(job.extracted_data || %{})
           else
             %{}
           end

--- a/lib/auto_my_invoice_web/live/upload_live.ex
+++ b/lib/auto_my_invoice_web/live/upload_live.ex
@@ -22,7 +22,14 @@ defmodule AutoMyInvoiceWeb.UploadLive do
     {:noreply, socket}
   end
 
-  @impl true
+  def handle_event("reset", _params, socket) do
+    # Allow the user to discard the current ExtractionJob view and return to
+    # the upload form so they can start over (e.g. after a low-confidence
+    # extraction or a failure). The ExtractionJob row is intentionally NOT
+    # deleted — historical jobs remain queryable for analytics and audit.
+    {:noreply, assign(socket, :extraction_job, nil)}
+  end
+
   def handle_event("upload", _params, socket) do
     user = socket.assigns.current_user
 
@@ -187,7 +194,7 @@ defmodule AutoMyInvoiceWeb.UploadLive do
                     >
                       <.icon name="hero-document-plus" class="size-4" /> 송장 생성
                     </.link>
-                    <button class="btn btn-ghost" phx-click="reset" phx-target="">
+                    <button type="button" class="btn btn-ghost" phx-click="reset">
                       다른 파일 업로드
                     </button>
                   </div>
@@ -196,7 +203,7 @@ defmodule AutoMyInvoiceWeb.UploadLive do
                     <.icon name="hero-x-circle" class="size-5" />
                     <span>추출 실패: {@extraction_job.error_message || "알 수 없는 오류"}</span>
                   </div>
-                  <button class="btn btn-ghost mt-4" phx-click="reset">
+                  <button type="button" class="btn btn-ghost mt-4" phx-click="reset">
                     다시 시도
                   </button>
               <% end %>

--- a/test/auto_my_invoice/ai/vision_client_test.exs
+++ b/test/auto_my_invoice/ai/vision_client_test.exs
@@ -1,9 +1,17 @@
 defmodule AutoMyInvoice.AI.VisionClientTest do
+  @moduledoc """
+  Unit tests for the pure helpers in `AutoMyInvoice.AI.VisionClient`.
+
+  Covers AC-6 from .hermes/seeds/AMI-84.md. Helpers exercised here are
+  exposed as `def` (originally `defp`) with `@doc false` specifically so
+  they can be unit tested without mocking the OpenAI HTTP layer.
+  """
+
   use ExUnit.Case
 
   alias AutoMyInvoice.AI.VisionClient
 
-  describe "extract/2" do
+  describe "extract/2 API key guard" do
     test "returns error when API key is not configured" do
       original = Application.get_env(:auto_my_invoice, :openai_api_key)
       Application.put_env(:auto_my_invoice, :openai_api_key, nil)
@@ -24,6 +32,110 @@ defmodule AutoMyInvoice.AI.VisionClientTest do
       Application.put_env(:auto_my_invoice, :openai_api_key, original)
 
       assert {:error, "OPENAI_API_KEY not configured"} = result
+    end
+  end
+
+  describe "parse_confidence/1" do
+    test "nil falls back to 0.5" do
+      assert VisionClient.parse_confidence(nil) == 0.5
+    end
+
+    test "valid float in [0.0, 1.0] is preserved" do
+      assert VisionClient.parse_confidence(0.85) == 0.85
+      assert VisionClient.parse_confidence(0.0) == 0.0
+      assert VisionClient.parse_confidence(1.0) == 1.0
+    end
+
+    test "integer is coerced to float" do
+      assert VisionClient.parse_confidence(1) == 1.0
+      assert VisionClient.parse_confidence(0) == 0.0
+    end
+
+    test "values above 1.0 clamp to 1.0" do
+      assert VisionClient.parse_confidence(1.5) == 1.0
+      assert VisionClient.parse_confidence(99) == 1.0
+    end
+
+    test "values below 0.0 clamp to 0.0" do
+      assert VisionClient.parse_confidence(-0.3) == 0.0
+      assert VisionClient.parse_confidence(-42) == 0.0
+    end
+
+    test "non-numeric input falls back to 0.5" do
+      assert VisionClient.parse_confidence("high") == 0.5
+      assert VisionClient.parse_confidence(%{}) == 0.5
+      assert VisionClient.parse_confidence([]) == 0.5
+    end
+  end
+
+  describe "strip_markdown_fences/1" do
+    test "removes ```json opening and ``` closing fences" do
+      input = "```json\n{\"amount\":\"100\"}\n```"
+      assert VisionClient.strip_markdown_fences(input) == "{\"amount\":\"100\"}"
+    end
+
+    test "is case-insensitive on the opening fence" do
+      assert VisionClient.strip_markdown_fences("```JSON\n{\"a\":1}\n```") =~ "{\"a\":1}"
+    end
+
+    test "leaves raw JSON without fences unchanged" do
+      raw = "{\"amount\":\"100\"}"
+      assert VisionClient.strip_markdown_fences(raw) == raw
+    end
+  end
+
+  describe "parse_response/1" do
+    test "success path extracts data and confidence, removing confidence from extracted_data" do
+      raw = %{
+        "choices" => [
+          %{
+            "message" => %{
+              "content" => ~s({"amount":"1500.00","currency":"KRW","confidence":0.9})
+            }
+          }
+        ]
+      }
+
+      assert {:ok, %{raw_response: ^raw, extracted_data: extracted, confidence: 0.9}} =
+               VisionClient.parse_response(raw)
+
+      assert extracted == %{"amount" => "1500.00", "currency" => "KRW"}
+      refute Map.has_key?(extracted, "confidence")
+    end
+
+    test "success path tolerates markdown-fenced JSON in the content" do
+      raw = %{
+        "choices" => [
+          %{
+            "message" => %{
+              "content" => "```json\n{\"amount\":\"100\",\"confidence\":1.0}\n```"
+            }
+          }
+        ]
+      }
+
+      assert {:ok, %{extracted_data: %{"amount" => "100"}, confidence: 1.0}} =
+               VisionClient.parse_response(raw)
+    end
+
+    test "missing confidence defaults to 0.5" do
+      raw = %{
+        "choices" => [%{"message" => %{"content" => ~s({"amount":"50"})}}]
+      }
+
+      assert {:ok, %{confidence: 0.5}} = VisionClient.parse_response(raw)
+    end
+
+    test "malformed JSON content returns {:error, _}" do
+      raw = %{"choices" => [%{"message" => %{"content" => "not valid json"}}]}
+
+      assert {:error, msg} = VisionClient.parse_response(raw)
+      assert msg =~ "Failed to parse"
+    end
+
+    test "unexpected response shape returns {:error, _}" do
+      assert {:error, msg} = VisionClient.parse_response(%{"something" => "else"})
+      assert msg =~ "Unexpected API response"
     end
   end
 end

--- a/test/auto_my_invoice_web/live/upload_live_test.exs
+++ b/test/auto_my_invoice_web/live/upload_live_test.exs
@@ -1,0 +1,115 @@
+defmodule AutoMyInvoiceWeb.UploadLiveTest do
+  @moduledoc """
+  LiveView tests for the receipt upload + AI extraction flow.
+
+  Covers AC-3 (reset event handler) and AC-5 (UploadLive integration tests)
+  from .hermes/seeds/AMI-84.md. Where possible we use Phoenix.LiveViewTest
+  end-to-end; where the LV is tightly coupled to PubSub broadcasts that
+  follow a real file upload, we drive the handler functions directly.
+  """
+
+  use AutoMyInvoiceWeb.ConnCase
+
+  import Phoenix.LiveViewTest
+
+  alias AutoMyInvoice.{Accounts, Extraction}
+  alias AutoMyInvoiceWeb.UploadLive
+
+  setup do
+    {:ok, user} =
+      Accounts.register_user(%{
+        email: "upload-live-test-#{System.unique_integer([:positive])}@example.com",
+        password: "validpassword123"
+      })
+
+    token = Accounts.generate_user_session_token(user)
+
+    conn =
+      build_conn()
+      |> init_test_session(%{user_token: token})
+
+    %{conn: conn, user: user}
+  end
+
+  defp create_pending_job(user) do
+    {:ok, job} =
+      Extraction.create_job(user.id, %{
+        file_url: "/uploads/test.png",
+        file_type: "png"
+      })
+
+    job
+  end
+
+  describe "GET /upload (T1)" do
+    test "renders the upload form when no extraction is in progress", %{conn: conn} do
+      {:ok, _view, html} = live(conn, ~p"/upload")
+
+      assert html =~ "송장 업로드"
+      assert html =~ "문서 업로드"
+    end
+
+    test "the upload page is gated to authenticated users" do
+      conn = build_conn()
+      assert {:error, {:redirect, %{to: redirect_to}}} = live(conn, ~p"/upload")
+      assert redirect_to =~ "/users/log_in"
+    end
+  end
+
+  describe "AC-3 reset handler" do
+    test "handle_event/3 for 'reset' clears extraction_job and re-renders the upload form" do
+      # Build a minimal socket with extraction_job pre-assigned, then call the
+      # handler directly. This is the most reliable way to exercise the reset
+      # path without going through the live_file_input fixture for an actual
+      # multipart upload.
+      job = %Extraction.ExtractionJob{
+        id: Ecto.UUID.generate(),
+        status: "completed",
+        extracted_data: %{"amount" => "100", "currency" => "KRW"},
+        confidence_score: 0.9
+      }
+
+      socket = %Phoenix.LiveView.Socket{assigns: %{extraction_job: job, __changed__: %{}}}
+
+      assert {:noreply, new_socket} = UploadLive.handle_event("reset", %{}, socket)
+      assert new_socket.assigns.extraction_job == nil
+    end
+  end
+
+  describe "AC-4 InvoiceLive.New prefill from completed extraction" do
+    test "navigating to /invoices/new?extraction_job_id=<id> populates the form prefill",
+         %{conn: conn, user: user} do
+      job = create_pending_job(user)
+
+      extracted = %{
+        "amount" => "1500.00",
+        "currency" => "KRW",
+        "due_date" => "2026-06-01",
+        "notes" => "Net 30",
+        "client_name" => "ACME"
+      }
+
+      {:ok, _completed} = Extraction.save_result(job, %{"raw" => "x"}, extracted, 0.92)
+
+      {:ok, _view, html} = live(conn, ~p"/invoices/new?extraction_job_id=#{job.id}")
+
+      assert html =~ "새 송장"
+      # Robust prefill signals: the amount and currency from extracted_data
+      # must appear in the rendered form. Before the AC-4 fix, the call
+      # `Extraction.to_invoice_attrs(job)` returned a fully-nil map because
+      # ExtractionJob structs do not implement Access on string keys, and
+      # neither 1500 nor KRW would be present.
+      assert html =~ "1500" or html =~ "1,500"
+      assert html =~ "KRW"
+    end
+
+    test "extraction job that is not yet completed leaves prefill empty",
+         %{conn: conn, user: user} do
+      # Pending job (status: "pending", extracted_data: nil)
+      job = create_pending_job(user)
+
+      {:ok, _view, html} = live(conn, ~p"/invoices/new?extraction_job_id=#{job.id}")
+      assert html =~ "새 송장"
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- AMI-84 (Sprint 3, 영수증 촬영 → AI 자동 송장 생성) 의 backend 파이프라인은 이미 90% 구현되어 있었으나, **두 가지 잠복 버그**와 **두 가지 테스트 누락**이 production-merge 를 막고 있었습니다.
- 본 PR 은 그 4 가지를 좁은 범위로 수정하고 회귀 테스트를 추가합니다.
- 테스트 254 → **273 (+19, 전부 그린)** / `make docker.precommit` 통과.

## Stack
- Base: \`feat/docker-dev-env\` (PR #7). 본 PR 은 그 위에 올라가 있습니다. #7 머지 후 \`main\` 으로 base 를 바꿔주시면 됩니다.

## Bugs fixed
1. **UploadLive — \`reset\` 이벤트 핸들러 미구현 (런타임 크래시)**
   템플릿의 성공 분기와 실패 분기 모두 \`phx-click=\"reset\"\` 버튼이 있었지만 \`handle_event(\"reset\", _, _)\` 절이 없어, 사용자가 \"다른 파일 업로드\" 또는 \"다시 시도\" 버튼을 누르면 LiveView 가 크래시했습니다. 또 두 버튼 모두 \`phx-target=\"\"\` (빈 문자열) 을 쓰고 있어 잘못된 사용이었습니다.
2. **InvoiceLive.New — \`to_invoice_attrs/1\` 타입 미스매치 (자동 채움 깨짐)**
   \`mount/3\` 에서 \`Extraction.to_invoice_attrs(job)\` 로 ExtractionJob 구조체를 넘기고 있었으나, 해당 함수는 string-keyed \`extracted_data\` 맵을 받습니다. Elixir 1.19 에서 Ecto 스키마 구조체는 Access 동작을 구현하지 않으므로 \`Access.get/3\` 가 raise 합니다. **모든 완료된 추출 후 \"송장 생성\" 클릭 시 크래시** 였습니다.

## Tests added
3. **\`test/auto_my_invoice_web/live/upload_live_test.exs\` (NEW)** — UploadLive 통합 테스트 5 건. GET /upload, 인증 리다이렉트, reset 핸들러, completed ExtractionJob 의 prefill flow, pending 상태 처리.
4. **\`test/auto_my_invoice/ai/vision_client_test.exs\` (EXTENDED)** — 기존 \`extract/2\` API key 가드 테스트 2 건은 보존하고, \`parse_confidence/1\` (6), \`strip_markdown_fences/1\` (3), \`parse_response/1\` (5) 의 엣지케이스 14 건을 추가. 헬퍼는 \`def\` + \`@doc false\` 로 노출 (테스트만을 위한 surface, 동작 변경 없음).

## Test Plan
- [x] 사전 baseline: \`make docker.test\` → 254 tests, 0 failures
- [x] 변경 후: \`make docker.precommit\` → **273 tests, 0 failures** (+19)
- [x] AC-3 검증: \`grep -q 'def handle_event(\"reset\"' lib/auto_my_invoice_web/live/upload_live.ex\`
- [x] AC-3 검증: \`! grep -q 'phx-target=\"\"' lib/auto_my_invoice_web/live/upload_live.ex\`
- [x] AC-4 검증: \`grep -q 'job.extracted_data' lib/auto_my_invoice_web/live/invoice_live/new.ex\`
- [ ] reviewer 가 \`gh pr checkout\` 후 \`make docker.precommit\` 재현 확인

## Notes — 의도적으로 하지 않은 것
- **daisyUI 클래스 제거 / \`<Layouts.app>\` wrapping** — AGENTS.md 의 \"no daisyUI\" 룰은 phx_new 의 generic 가이드라인이지만, 이 프로젝트의 실제 컨벤션 (\`assets/css/app.css\` 의 \`@plugin \"../vendor/daisyui\"\`, 19 개 LiveView 가 daisyUI 사용) 과 충돌합니다. AMI-84 범위 안에서 강제하면 시각적 회귀 위험이 크고 19 개 파일 마이그레이션이 필요해, **별도 디자인 시스템 epic** 으로 미루었습니다.
- **AMI-85 / AMI-86 / AMI-87** — 별도 티켓.
- **OPENAI_API_KEY 미설정 환경 fallback / 일일 한도 / 업로드 파일 GC / prod Dockerfile Elixir 버전 정렬** — 별도 백로그.
- **\`packages/api-spec/openapi.yaml\`** — 본 PR 은 UI + worker-internal 만 손대므로 API surface 변경 없음, openapi 갱신 불필요.

## Closes
\`Closes AMI-84\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>