### PR TITLE
feat(AMI-86): brand-aware emails (company_name + brand_color)

### DIFF
--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -52,6 +52,11 @@ jobs:
           elixir-version: ${{ env.ELIXIR_VERSION }}
           otp-version: ${{ env.OTP_VERSION }}
 
+      - name: Install Chromium for ChromicPDF
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y chromium
+
       - name: Cache deps
         uses: actions/cache@v4
         with:

--- a/lib/auto_my_invoice/accounts/user.ex
+++ b/lib/auto_my_invoice/accounts/user.ex
@@ -15,6 +15,7 @@ defmodule AutoMyInvoice.Accounts.User do
     field :company_name, :string
     field :timezone, :string, default: "Asia/Seoul"
     field :brand_tone, :string, default: "professional"
+    field :brand_color, :string
 
     # OAuth
     field :google_uid, :string
@@ -31,6 +32,7 @@ defmodule AutoMyInvoice.Accounts.User do
     :company_name,
     :timezone,
     :brand_tone,
+    :brand_color,
     :google_uid,
     :avatar_url,
     :plan,
@@ -56,6 +58,9 @@ defmodule AutoMyInvoice.Accounts.User do
     |> cast(attrs, @optional_fields)
     |> validate_inclusion(:brand_tone, ~w(professional friendly formal))
     |> validate_inclusion(:plan, ~w(free starter pro))
+    |> validate_format(:brand_color, ~r/^#[0-9A-Fa-f]{6}$/,
+      message: "must be a hex color like #RRGGBB"
+    )
   end
 
   def valid_password?(%__MODULE__{hashed_password: hashed_password}, password)

--- a/lib/auto_my_invoice/emails/invoice_email.ex
+++ b/lib/auto_my_invoice/emails/invoice_email.ex
@@ -3,22 +3,36 @@ defmodule AutoMyInvoice.Emails.InvoiceEmail do
 
   import Swoosh.Email
 
-  @from_name "AutoMyInvoice"
+  @default_from_name "AutoMyInvoice"
+  @default_brand_color "#111"
 
   @spec invoice_sent(map()) :: Swoosh.Email.t()
-  def invoice_sent(%{invoice: invoice, client: client, from_email: from_email}) do
+  def invoice_sent(%{invoice: invoice, client: client, from_email: from_email} = args) do
+    user = Map.get(args, :user)
     due_date = format_date(invoice.due_date)
     amount = format_amount(invoice.amount, invoice.currency)
+    from_name = brand_from_name(user)
+    brand_color = brand_color(user)
+    company_label = brand_company_label(user)
 
     new()
     |> to({client.name, client.email})
-    |> from({@from_name, from_email})
+    |> from({from_name, from_email})
     |> subject("[송장 #{invoice.invoice_number}] #{amount} · 기한 #{due_date}")
-    |> html_body(html_body(invoice, client, due_date, amount))
-    |> text_body(text_body(invoice, client, due_date, amount))
+    |> html_body(html_body(invoice, client, due_date, amount, brand_color, company_label))
+    |> text_body(text_body(invoice, client, due_date, amount, company_label))
   end
 
-  defp html_body(invoice, client, due_date, amount) do
+  defp brand_from_name(%{company_name: name}) when is_binary(name) and name != "", do: name
+  defp brand_from_name(_), do: @default_from_name
+
+  defp brand_color(%{brand_color: color}) when is_binary(color) and color != "", do: color
+  defp brand_color(_), do: @default_brand_color
+
+  defp brand_company_label(%{company_name: name}) when is_binary(name) and name != "", do: name
+  defp brand_company_label(_), do: @default_from_name
+
+  defp html_body(invoice, client, due_date, amount, brand_color, company_label) do
     """
     <!DOCTYPE html>
     <html lang="ko">
@@ -26,7 +40,7 @@ defmodule AutoMyInvoice.Emails.InvoiceEmail do
       <meta charset="UTF-8" />
       <style>
         body { font-family: -apple-system, BlinkMacSystemFont, "Malgun Gothic", sans-serif; color: #333; max-width: 600px; margin: 0 auto; padding: 24px; }
-        .header { font-size: 22px; font-weight: bold; margin-bottom: 16px; }
+        .header { background-color: #{brand_color}; color: #fff; font-size: 22px; font-weight: bold; padding: 16px; border-radius: 6px; margin-bottom: 16px; }
         .details { background: #f9f9f9; border-radius: 6px; padding: 16px; margin: 16px 0; }
         .row { display: flex; justify-content: space-between; margin-bottom: 8px; }
         .label { color: #666; }
@@ -45,13 +59,13 @@ defmodule AutoMyInvoice.Emails.InvoiceEmail do
       </div>
       #{if invoice.notes, do: "<p><strong>메모:</strong> #{invoice.notes}</p>", else: ""}
       <p>기한 내 결제 부탁드립니다. 문의사항은 이 이메일에 답장해 주세요.</p>
-      <div class="footer">본 송장은 AutoMyInvoice를 통해 발송되었습니다.</div>
+      <div class="footer">본 송장은 #{company_label}에서 AutoMyInvoice를 통해 발송되었습니다.</div>
     </body>
     </html>
     """
   end
 
-  defp text_body(invoice, client, due_date, amount) do
+  defp text_body(invoice, client, due_date, amount, company_label) do
     notes_section =
       if invoice.notes, do: "\n메모: #{invoice.notes}\n", else: ""
 
@@ -70,7 +84,7 @@ defmodule AutoMyInvoice.Emails.InvoiceEmail do
     문의사항은 이 이메일에 답장해 주세요.
 
     --
-    AutoMyInvoice
+    #{company_label} (via AutoMyInvoice)
     """
   end
 

--- a/lib/auto_my_invoice/emails/overdue_email.ex
+++ b/lib/auto_my_invoice/emails/overdue_email.ex
@@ -3,10 +3,12 @@ defmodule AutoMyInvoice.Emails.OverdueEmail do
 
   import Swoosh.Email
 
-  @from_name "AutoMyInvoice"
+  @default_from_name "AutoMyInvoice"
+  @default_brand_color "#dc2626"
 
   @spec build(map()) :: Swoosh.Email.t()
-  def build(%{invoice: invoice, client: client, from_email: from_email}) do
+  def build(%{invoice: invoice, client: client, from_email: from_email} = args) do
+    user = Map.get(args, :user)
     due_date = Calendar.strftime(invoice.due_date, "%Y년 %m월 %d일")
     amount = format_amount(invoice.amount, invoice.currency)
     days_overdue = Date.diff(Date.utc_today(), invoice.due_date)
@@ -18,18 +20,25 @@ defmodule AutoMyInvoice.Emails.OverdueEmail do
       amount: amount,
       due_date: due_date,
       days_overdue: days_overdue,
-      payment_link: payment_link
+      payment_link: payment_link,
+      brand_color: brand_color(user)
     }
 
     {subject, html, text} = build_content(assigns)
 
     new()
     |> to({client.name, client.email})
-    |> from({@from_name, from_email})
+    |> from({brand_from_name(user), from_email})
     |> subject(subject)
     |> html_body(html)
     |> text_body(text)
   end
+
+  defp brand_from_name(%{company_name: name}) when is_binary(name) and name != "", do: name
+  defp brand_from_name(_), do: @default_from_name
+
+  defp brand_color(%{brand_color: color}) when is_binary(color) and color != "", do: color
+  defp brand_color(_), do: @default_brand_color
 
   defp build_content(assigns) do
     subject = "연체 알림: 송장 #{assigns.invoice_number} — #{assigns.amount} 미납"
@@ -39,15 +48,15 @@ defmodule AutoMyInvoice.Emails.OverdueEmail do
     <html>
     <head><meta charset="UTF-8" />#{styles()}</head>
     <body>
-      <div class="header" style="color:#c62828;">연체 알림</div>
+      <div class="header" style="background-color:#{assigns.brand_color}; color:#fff; padding:16px; border-radius:6px;">연체 알림</div>
       <p>#{assigns.client_name}님께,</p>
       <p>송장 <strong>#{assigns.invoice_number}</strong>의 결제 기한이 <strong>#{assigns.days_overdue}일</strong> 경과하였습니다.
       아래 내역을 확인하시고 조속한 결제를 부탁드립니다.</p>
-      <div class="details" style="border-left: 4px solid #c62828;">
+      <div class="details" style="border-left: 4px solid #{assigns.brand_color};">
         <div class="row"><span class="label">송장 번호</span><span>#{assigns.invoice_number}</span></div>
-        <div class="row"><span class="label">미납 금액</span><span class="amount" style="color:#c62828;">#{assigns.amount}</span></div>
+        <div class="row"><span class="label">미납 금액</span><span class="amount" style="color:#{assigns.brand_color};">#{assigns.amount}</span></div>
         <div class="row"><span class="label">결제 기한</span><span>#{assigns.due_date}</span></div>
-        <div class="row"><span class="label">연체 일수</span><span style="color:#c62828; font-weight:bold;">#{assigns.days_overdue}일</span></div>
+        <div class="row"><span class="label">연체 일수</span><span style="color:#{assigns.brand_color}; font-weight:bold;">#{assigns.days_overdue}일</span></div>
       </div>
       <p>이미 결제를 완료하셨다면 이 알림을 무시해 주세요.
       결제에 어려움이 있으시면 회신하여 주시기 바랍니다.</p>

--- a/lib/auto_my_invoice/emails/reminder_email.ex
+++ b/lib/auto_my_invoice/emails/reminder_email.ex
@@ -3,10 +3,14 @@ defmodule AutoMyInvoice.Emails.ReminderEmail do
 
   import Swoosh.Email
 
-  @from_name "AutoMyInvoice"
+  @default_from_name "AutoMyInvoice"
+  @default_brand_color "#0f172a"
 
   @spec build(map()) :: Swoosh.Email.t()
-  def build(%{reminder: reminder, invoice: invoice, client: client, from_email: from_email}) do
+  def build(
+        %{reminder: reminder, invoice: invoice, client: client, from_email: from_email} = args
+      ) do
+    user = Map.get(args, :user)
     due_date = format_date(invoice.due_date)
     amount = format_amount(invoice.amount, invoice.currency)
     days_overdue = Date.diff(Date.utc_today(), invoice.due_date)
@@ -28,18 +32,25 @@ defmodule AutoMyInvoice.Emails.ReminderEmail do
         amount: amount,
         due_date: due_date,
         days_overdue: days_overdue,
-        payment_link: tracked_payment_link
+        payment_link: tracked_payment_link,
+        brand_color: brand_color(user)
       })
 
     html = html <> tracking_pixel(base_url, reminder_id)
 
     new()
     |> to({client.name, client.email})
-    |> from({@from_name, from_email})
+    |> from({brand_from_name(user), from_email})
     |> subject(subject)
     |> html_body(html)
     |> text_body(text)
   end
+
+  defp brand_from_name(%{company_name: name}) when is_binary(name) and name != "", do: name
+  defp brand_from_name(_), do: @default_from_name
+
+  defp brand_color(%{brand_color: color}) when is_binary(color) and color != "", do: color
+  defp brand_color(_), do: @default_brand_color
 
   # Step 0: 수동 리마인더 (친근한 톤)
   defp content_for_step(0, assigns) do
@@ -50,7 +61,7 @@ defmodule AutoMyInvoice.Emails.ReminderEmail do
     <html lang="ko">
     <head><meta charset="UTF-8" />#{styles()}</head>
     <body>
-      <div class="header">결제 안내</div>
+      <div class="header" style="background-color:#{assigns.brand_color}; color:#fff; padding:14px; border-radius:6px;">결제 안내</div>
       <p>#{assigns.client_name} 담당자님께,</p>
       <p>송장 <strong>#{assigns.invoice_number}</strong> (<strong>#{assigns.amount}</strong>)의
       지급 기한이 <strong>#{assigns.due_date}</strong>이었음을 알려드립니다.</p>
@@ -94,7 +105,7 @@ defmodule AutoMyInvoice.Emails.ReminderEmail do
     <html lang="ko">
     <head><meta charset="UTF-8" />#{styles()}</head>
     <body>
-      <div class="header">결제 안내</div>
+      <div class="header" style="background-color:#{assigns.brand_color}; color:#fff; padding:14px; border-radius:6px;">결제 안내</div>
       <p>#{assigns.client_name} 담당자님께,</p>
       <p>송장 <strong>#{assigns.invoice_number}</strong> (<strong>#{assigns.amount}</strong>)의
       지급 기한이 <strong>#{assigns.due_date}</strong>이었습니다.</p>
@@ -137,7 +148,7 @@ defmodule AutoMyInvoice.Emails.ReminderEmail do
     <html lang="ko">
     <head><meta charset="UTF-8" />#{styles()}</head>
     <body>
-      <div class="header">결제 확인 요청</div>
+      <div class="header" style="background-color:#{assigns.brand_color}; color:#fff; padding:14px; border-radius:6px;">결제 확인 요청</div>
       <p>#{assigns.client_name} 담당자님께,</p>
       <p>송장 <strong>#{assigns.invoice_number}</strong> (<strong>#{assigns.amount}</strong>)
       건에 대해 확인 부탁드립니다. 지급 기한은 #{assigns.due_date}이었고,
@@ -184,7 +195,7 @@ defmodule AutoMyInvoice.Emails.ReminderEmail do
     <html lang="ko">
     <head><meta charset="UTF-8" />#{styles()}</head>
     <body>
-      <div class="header" style="color:#c62828;">결제 최종 통보</div>
+      <div class="header" style="background-color:#{assigns.brand_color}; color:#fff; padding:14px; border-radius:6px;">결제 최종 통보</div>
       <p>#{assigns.client_name} 담당자님께,</p>
       <p>송장 <strong>#{assigns.invoice_number}</strong> (<strong>#{assigns.amount}</strong>)
       건에 대한 최종 안내입니다. 현재 <strong>#{assigns.days_overdue}일 연체</strong> 상태입니다.</p>

--- a/lib/auto_my_invoice/invoices.ex
+++ b/lib/auto_my_invoice/invoices.ex
@@ -113,13 +113,14 @@ defmodule AutoMyInvoice.Invoices do
     case Repo.transaction(multi) do
       {:ok, %{mark_sent: sent_invoice}} ->
         broadcast_invoice_change(sent_invoice)
-        sent_invoice = maybe_create_payment_link(Repo.preload(sent_invoice, :client))
+        sent_invoice = maybe_create_payment_link(Repo.preload(sent_invoice, [:client, :user]))
 
         email =
           InvoiceEmail.invoice_sent(%{
             invoice: sent_invoice,
             client: sent_invoice.client,
-            from_email: sender_email()
+            from_email: sender_email(),
+            user: sent_invoice.user
           })
 
         Mailer.deliver(email)

--- a/lib/auto_my_invoice/workers/overdue_notification_worker.ex
+++ b/lib/auto_my_invoice/workers/overdue_notification_worker.ex
@@ -28,7 +28,7 @@ defmodule AutoMyInvoice.Workers.OverdueNotificationWorker do
   end
 
   defp maybe_preload(nil), do: nil
-  defp maybe_preload(invoice), do: Repo.preload(invoice, :client)
+  defp maybe_preload(invoice), do: Repo.preload(invoice, [:client, :user])
 
   defp validate_invoice(nil), do: {:cancel, "invoice not found"}
   defp validate_invoice(%{overdue_notified_at: notified_at}) when not is_nil(notified_at), do: :ok
@@ -56,7 +56,8 @@ defmodule AutoMyInvoice.Workers.OverdueNotificationWorker do
       OverdueEmail.build(%{
         invoice: invoice,
         client: client,
-        from_email: from_email
+        from_email: from_email,
+        user: Map.get(invoice, :user)
       })
 
     case Mailer.deliver(email) do

--- a/lib/auto_my_invoice/workers/reminder_worker.ex
+++ b/lib/auto_my_invoice/workers/reminder_worker.ex
@@ -20,7 +20,7 @@ defmodule AutoMyInvoice.Workers.ReminderWorker do
     reminder =
       Reminder
       |> Repo.get(reminder_id)
-      |> Repo.preload(invoice: :client)
+      |> Repo.preload(invoice: [:client, :user])
 
     case reminder do
       nil ->
@@ -50,7 +50,8 @@ defmodule AutoMyInvoice.Workers.ReminderWorker do
         reminder: reminder_with_tracking,
         invoice: invoice,
         client: client,
-        from_email: from_email
+        from_email: from_email,
+        user: invoice.user
       })
 
     case Mailer.deliver(email) do

--- a/priv/repo/migrations/20260515000001_add_brand_color_to_users.exs
+++ b/priv/repo/migrations/20260515000001_add_brand_color_to_users.exs
@@ -1,0 +1,9 @@
+defmodule AutoMyInvoice.Repo.Migrations.AddBrandColorToUsers do
+  use Ecto.Migration
+
+  def change do
+    alter table(:users) do
+      add :brand_color, :string
+    end
+  end
+end

--- a/test/auto_my_invoice/accounts/user_test.exs
+++ b/test/auto_my_invoice/accounts/user_test.exs
@@ -1,0 +1,39 @@
+defmodule AutoMyInvoice.Accounts.UserTest do
+  use AutoMyInvoice.DataCase, async: true
+
+  alias AutoMyInvoice.Accounts.User
+
+  describe "profile_changeset/2 brand_color validation" do
+    test "accepts a valid hex color like #RRGGBB" do
+      changeset = User.profile_changeset(%User{}, %{brand_color: "#ff5722"})
+      assert changeset.valid?
+      assert get_field(changeset, :brand_color) == "#ff5722"
+    end
+
+    test "accepts uppercase hex" do
+      changeset = User.profile_changeset(%User{}, %{brand_color: "#FF5722"})
+      assert changeset.valid?
+    end
+
+    test "allows nil (optional)" do
+      changeset = User.profile_changeset(%User{}, %{brand_color: nil})
+      assert changeset.valid?
+    end
+
+    test "rejects malformed hex (missing hash)" do
+      changeset = User.profile_changeset(%User{}, %{brand_color: "ff5722"})
+      refute changeset.valid?
+      assert %{brand_color: [_]} = errors_on(changeset)
+    end
+
+    test "rejects 3-digit shorthand" do
+      changeset = User.profile_changeset(%User{}, %{brand_color: "#abc"})
+      refute changeset.valid?
+    end
+
+    test "rejects non-hex characters" do
+      changeset = User.profile_changeset(%User{}, %{brand_color: "#zz5722"})
+      refute changeset.valid?
+    end
+  end
+end

--- a/test/auto_my_invoice/emails/invoice_email_test.exs
+++ b/test/auto_my_invoice/emails/invoice_email_test.exs
@@ -1,0 +1,102 @@
+defmodule AutoMyInvoice.Emails.InvoiceEmailTest do
+  use AutoMyInvoice.DataCase, async: true
+
+  alias AutoMyInvoice.Emails.InvoiceEmail
+
+  defp build_invoice(attrs \\ %{}) do
+    base = %{
+      invoice_number: "INV-2026-0001",
+      amount: Decimal.new(1500),
+      currency: "KRW",
+      due_date: ~D[2026-06-30],
+      notes: nil
+    }
+
+    Map.merge(base, attrs)
+  end
+
+  defp build_client(attrs \\ %{}) do
+    base = %{name: "테스트클라이언트", email: "client@example.com"}
+    Map.merge(base, attrs)
+  end
+
+  defp build_user(attrs \\ %{}) do
+    base = %{company_name: nil, brand_color: nil}
+    Map.merge(base, attrs)
+  end
+
+  describe "invoice_sent/1 — default (no user)" do
+    test "uses AutoMyInvoice as from name when user is absent (backward-compat)" do
+      email =
+        InvoiceEmail.invoice_sent(%{
+          invoice: build_invoice(),
+          client: build_client(),
+          from_email: "noreply@automyinvoice.app"
+        })
+
+      assert {"AutoMyInvoice", "noreply@automyinvoice.app"} = email.from
+    end
+
+    test "renders amount with thousand separator and KRW symbol" do
+      email =
+        InvoiceEmail.invoice_sent(%{
+          invoice: build_invoice(%{amount: Decimal.new(1_500_000)}),
+          client: build_client(),
+          from_email: "noreply@automyinvoice.app"
+        })
+
+      assert email.html_body =~ "₩1,500,000"
+      assert email.text_body =~ "₩1,500,000"
+    end
+  end
+
+  describe "invoice_sent/1 — brand-aware (user provided)" do
+    test "uses user.company_name as from name when present" do
+      email =
+        InvoiceEmail.invoice_sent(%{
+          invoice: build_invoice(),
+          client: build_client(),
+          from_email: "noreply@automyinvoice.app",
+          user: build_user(%{company_name: "주식회사 코끼리"})
+        })
+
+      assert {"주식회사 코끼리", "noreply@automyinvoice.app"} = email.from
+    end
+
+    test "falls back to AutoMyInvoice when company_name is nil even if user is given" do
+      email =
+        InvoiceEmail.invoice_sent(%{
+          invoice: build_invoice(),
+          client: build_client(),
+          from_email: "noreply@automyinvoice.app",
+          user: build_user()
+        })
+
+      assert {"AutoMyInvoice", "noreply@automyinvoice.app"} = email.from
+    end
+
+    test "applies brand_color to header background when present" do
+      email =
+        InvoiceEmail.invoice_sent(%{
+          invoice: build_invoice(),
+          client: build_client(),
+          from_email: "noreply@automyinvoice.app",
+          user: build_user(%{brand_color: "#ff5722"})
+        })
+
+      assert email.html_body =~ "#ff5722"
+    end
+
+    test "company_name appears in HTML footer when set" do
+      email =
+        InvoiceEmail.invoice_sent(%{
+          invoice: build_invoice(),
+          client: build_client(),
+          from_email: "noreply@automyinvoice.app",
+          user: build_user(%{company_name: "주식회사 코끼리"})
+        })
+
+      assert email.html_body =~ "주식회사 코끼리"
+    end
+  end
+end

--- a/test/auto_my_invoice/emails/overdue_email_test.exs
+++ b/test/auto_my_invoice/emails/overdue_email_test.exs
@@ -68,5 +68,16 @@ defmodule AutoMyInvoice.Emails.OverdueEmailTest do
       email = OverdueEmail.build(build_assigns())
       refute email.html_body =~ "지금 결제하기"
     end
+
+    test "uses user.company_name as from name and applies brand_color to header" do
+      assigns =
+        build_assigns()
+        |> Map.put(:user, %{company_name: "코끼리상사", brand_color: "#ff5722"})
+
+      email = OverdueEmail.build(assigns)
+
+      assert {"코끼리상사", "noreply@automyinvoice.app"} = email.from
+      assert email.html_body =~ "#ff5722"
+    end
   end
 end

--- a/test/auto_my_invoice/emails/reminder_email_test.exs
+++ b/test/auto_my_invoice/emails/reminder_email_test.exs
@@ -76,5 +76,16 @@ defmodule AutoMyInvoice.Emails.ReminderEmailTest do
       email = ReminderEmail.build(build_assigns(1))
       refute email.html_body =~ "바로 결제하기"
     end
+
+    test "uses user.company_name as from name and applies brand_color to header" do
+      assigns =
+        build_assigns(1)
+        |> Map.put(:user, %{company_name: "코끼리상사", brand_color: "#ff5722"})
+
+      email = ReminderEmail.build(assigns)
+
+      assert {"코끼리상사", "noreply@automyinvoice.app"} = email.from
+      assert email.html_body =~ "#ff5722"
+    end
   end
 end


### PR DESCRIPTION
## Summary
AMI-86 (Sprint 3, 내 브랜드로 이메일 커스터마이징) 의 백엔드 기반. 사용자가 송장/연체/리마인더 이메일에 자기 회사명과 브랜드 컬러를 반영할 수 있게 한다. 본 PR 은 **데이터 모델 + 이메일 빌더 통합**까지만 다루고, Settings UI 는 별도 PR.

## Bug-free changes
- **DB**: \`users.brand_color\` 컬럼 추가 (string, hex, nullable). migration up/down 무해.
- **Schema**: \`User.brand_color\` + \`profile_changeset\` 에 \`#RRGGBB\` 정규식 검증.
- **Email builders 3종**: \`InvoiceEmail.invoice_sent/1\`, \`OverdueEmail.build/1\`, \`ReminderEmail.build/1\` 모두 \`user\` 옵션 키 받음.
  - \`from\` name: \`user.company_name || \"AutoMyInvoice\"\`
  - HTML header background: \`user.brand_color || default\`
  - InvoiceEmail footer 라벨: \`user.company_name\`
  - **호환성**: user 가 nil 이거나 \`company_name\` 이 nil 이면 모두 \`\"AutoMyInvoice\"\` 로 폴백 → 기존 호출자/테스트 안 깨짐.
- **Invoices.send_invoice/1**: \`Repo.preload([:client, :user])\` → 빌더에 user 전달.
- **ReminderWorker / OverdueNotificationWorker**: invoice preload 에 \`:user\` 추가.

## Tests (+14)
- \`test/auto_my_invoice/emails/invoice_email_test.exs\` (NEW, 6): default fallback / company_name / brand_color HTML / nil fallback / KRW 포맷 / footer 회사명
- \`overdue_email_test.exs\` (+1): brand-aware
- \`reminder_email_test.exs\` (+1): brand-aware
- \`test/auto_my_invoice/accounts/user_test.exs\` (NEW, 6): hex 형식 검증 valid/uppercase/nil/no-hash/3-digit/non-hex

## Test Plan
- [x] baseline: 273 / 0 failures
- [x] 변경 후: **287 / 0 failures** (+14)
- [x] \`mix format --check-formatted\` clean
- [x] \`mix compile --warnings-as-errors\` clean

## Out of Scope (별도 PR / epic)
- Settings UI (color picker, company_name 입력)
- 로고 이미지 업로드 (S3 정책 필요, BACKLOG #34)
- PDF 송장 디자인 brand 반영
- openapi.yaml 변경 없음 (internal 백엔드만)
- 이메일 발신 도메인 (SPF/DKIM)

## Closes
Closes AMI-86

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>