### PR TITLE
fix(ci): restore iOS test target, run tests in iOS CI

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -23,15 +23,12 @@ jobs:
         with:
           xcode-version: latest-stable
 
-      # NOTE: The Tests target (InVoiceFlow_iOSTests) is not yet wired into the
-      # Xcode project (no PBXNativeTarget entry), so `xcodebuild test` fails with
-      # "scheme is not configured for the test action". Until the test target is
-      # restored via Xcode, CI verifies that the app compiles (build-only).
-      - name: Build
+      - name: Build and Test
         working-directory: apps/ios/InVoiceFlow_iOS
         run: |
-          xcodebuild build \
+          xcodebuild test \
             -project InVoiceFlow_iOS.xcodeproj \
             -scheme InVoiceFlow_iOS \
-            -destination 'generic/platform=iOS Simulator' \
+            -destination 'platform=iOS Simulator,name=iPhone 16,OS=latest' \
+            -resultBundlePath TestResults \
             CODE_SIGNING_ALLOWED=NO

--- a/apps/ios/InVoiceFlow_iOS/InVoiceFlow_iOS.xcodeproj/xcshareddata/xcschemes/InVoiceFlow_iOS.xcscheme
+++ b/apps/ios/InVoiceFlow_iOS/InVoiceFlow_iOS.xcodeproj/xcshareddata/xcschemes/InVoiceFlow_iOS.xcscheme
@@ -28,6 +28,16 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A1000005000000000000001"
+               BuildableName = "InVoiceFlow_iOSTests.xctest"
+               BlueprintName = "InVoiceFlow_iOSTests"
+               ReferencedContainer = "container:InVoiceFlow_iOS.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction


### PR DESCRIPTION
## Summary
- iOS CI를 build-only에서 `xcodebuild test`로 되돌립니다.
- PR #12에서 iOS CI를 임시로 build-only로 낮췄는데, 그 원인 진단이 부정확했습니다. 실제로는 테스트 타깃이 온전했고 공유 스킴의 `<Testables>`만 비어 있었던 것입니다.

## Changes
- 공유 스킴 `InVoiceFlow_iOS.xcscheme`의 `<Testables>`에 `InVoiceFlow_iOSTests` 참조 복원
- `.github/workflows/ios.yml`: `xcodebuild build` → `xcodebuild test`

## Test Plan
- [x] 로컬 `xcodebuild test` (iPhone 16 시뮬): **TEST SUCCEEDED**, 23 tests / 0 failures
  - PdfApiServiceTests (9), RecordPaymentRequestTests (7), ReminderRepositoryTests (7)
- [ ] iOS CI (macos-15)에서 test 통과 확인

## Notes
- 이전 PR #12 커밋 메시지/워크플로 주석의 "테스트 타깃 미연결(PBXNativeTarget 부재)" 진단은 정규식 파싱 오류였습니다. 본 PR이 이를 정정합니다.
- macos-15 + latest-stable Xcode(objectVersion 77 호환)는 PR #12에서 이미 적용됨.