### PR TITLE
test: fix flaky RateLimitTest (global rate-limit ETS race)

### DIFF
--- a/test/auto_my_invoice_web/controllers/api/auth_controller_test.exs
+++ b/test/auto_my_invoice_web/controllers/api/auth_controller_test.exs
@@ -1,5 +1,10 @@
 defmodule AutoMyInvoiceWeb.Api.AuthControllerTest do
-  use AutoMyInvoiceWeb.ConnCase
+  # async: false — this suite hits POST /api/v1/auth/login, which shares the
+  # global rate-limit ETS bucket. RateLimitTest toggles :rate_limit_enabled on
+  # globally; if this suite ran concurrently it could pollute that bucket (or be
+  # rate-limited itself), making RateLimitTest's 11th-request assertion flaky.
+  # Serializing the two login-hitting suites removes that race.
+  use AutoMyInvoiceWeb.ConnCase, async: false
 
   alias AutoMyInvoice.Accounts
   alias AutoMyInvoiceWeb.Plugs.ApiAuth

--- a/test/auto_my_invoice_web/rate_limit_test.exs
+++ b/test/auto_my_invoice_web/rate_limit_test.exs
@@ -12,6 +12,15 @@ defmodule AutoMyInvoiceWeb.RateLimitTest do
   alias AutoMyInvoice.RateLimiter
 
   setup do
+    # Clear the shared Hammer ETS bucket (table is named after the limiter module)
+    # so counters from earlier tests/runs never bleed into this scenario. Guard
+    # against the table not existing yet.
+    try do
+      :ets.delete_all_objects(RateLimiter)
+    rescue
+      ArgumentError -> :ok
+    end
+
     prev = Application.get_env(:auto_my_invoice, :rate_limit_enabled)
     Application.put_env(:auto_my_invoice, :rate_limit_enabled, true)
 
@@ -76,10 +85,15 @@ defmodule AutoMyInvoiceWeb.RateLimitTest do
   end
 
   defp unique_ip do
-    # ETS buckets persist across tests in the same VM run, so each test
-    # uses a private RFC 5737 documentation IP it's never used before.
-    n = System.unique_integer([:positive]) |> rem(254)
-    {198, 51, 100, n + 1}
+    # ETS buckets persist across tests in the same VM run, so each test must use
+    # an IP it has never used before. The old `rem(254)` collapsed every id into a
+    # single /24 (only 254 distinct IPs), so once enough tests ran the documentation
+    # block wrapped around and buckets bled between tests — making the 11th-request
+    # assertion flaky (a reused IP could already be over/under the limit).
+    # Spread the unique id across two octets of the 10.0.0.0/8 test range so the
+    # effective space is ~65k distinct IPs, far beyond any single run's test count.
+    n = System.unique_integer([:positive])
+    {10, 0, div(n, 254) |> rem(254), rem(n, 254) + 1}
   end
 
   # Sanity: the limiter itself counts hits per key correctly.


### PR DESCRIPTION
## Summary
- `RateLimitTest`가 CI에서 간헐 실패(11번째 요청이 429 대신 401)하던 flaky를 근본 수정합니다. Elixir 1.20 전환 PR(#14) 머지 후 main CI에서 1회 노출됐고, 재실행 시 통과해 flaky로 확인됐습니다.

## Root cause
전역 `:rate_limit_enabled` 플래그를 켠 동안, **async인 `AuthControllerTest`**가 `POST /api/v1/auth/login`을 쳐서 공유 Hammer ETS 버킷을 오염시키는 **테스트 간 race**. (1.20 자체와 무관 — 실행 순서가 바뀌며 노출됐을 뿐)

## Fix (3중 방어)
- **`auth_controller_test.exs` → `async: false`**: login을 치는 두 스위트(RateLimitTest·AuthControllerTest)를 직렬화해 race 자체 제거 (핵심)
- **`rate_limit_test.exs` setup에 ETS 클리어**: `:ets.delete_all_objects(RateLimiter)`로 이전 런 잔존 카운터 제거 (moduledoc이 약속했으나 미구현이던 부분 이행)
- **`unique_ip` 확장**: `rem(254)` 단일 /24(254개) → `10.0.x.y`(~65k)로 스위트 내부 IP 충돌도 차단

## Test Plan
- [x] `mix test` 전체 526개 **3회 연속 통과** (0 failures)
- [ ] CI에서 통과 확인

## Notes
- flaky는 본래 재현이 드물어 로컬 반복으로 완벽 증명은 어렵지만, async:false 직렬화로 race 조건 자체를 구조적으로 제거했습니다.