### PR TITLE
fix: switch FX rate provider to open.er-api.com

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -46,9 +46,9 @@ config :auto_my_invoice, Oban,
      crontab: [
        {"0 * * * *", AutoMyInvoice.Workers.ReminderScheduler},
        {"0 9 * * *", AutoMyInvoice.Workers.OverdueScanner},
-       # AMI-90: 18:00 UTC = 03:00 Asia/Seoul, right after exchangerate.host
-       # rotates its daily rates and well before Korean business hours.
-       {"0 18 * * *", AutoMyInvoice.Workers.FxRateRefreshWorker}
+       # AMI-90: open.er-api.com rotates its daily rates at ~00:06 UTC, so
+       # 01:00 UTC (10:00 Asia/Seoul) always picks up same-day quotes.
+       {"0 1 * * *", AutoMyInvoice.Workers.FxRateRefreshWorker}
      ]}
   ]
 

--- a/config/test.exs
+++ b/config/test.exs
@@ -45,6 +45,11 @@ config :auto_my_invoice, Oban, testing: :inline
 # rates and lives under test/support.
 config :auto_my_invoice, AutoMyInvoice.FxRates, client: AutoMyInvoice.FxRatesStub
 
+# HttpClient unit tests exercise the real parsing/inversion logic against a
+# Req.Test stub instead of the live open.er-api.com endpoint.
+config :auto_my_invoice, AutoMyInvoice.FxRates.HttpClient,
+  req_options: [plug: {Req.Test, AutoMyInvoice.FxRates.HttpClient}, retry: false]
+
 # ChromicPDF: disable Chrome sandbox so tests can boot inside Docker (or any
 # unprivileged container) without requiring a user-namespace sandbox profile.
 config :auto_my_invoice, ChromicPDF, chrome_args: "--no-sandbox"

--- a/lib/auto_my_invoice/fx_rates/client.ex
+++ b/lib/auto_my_invoice/fx_rates/client.ex
@@ -7,21 +7,27 @@ end
 
 defmodule AutoMyInvoice.FxRates.HttpClient do
   @moduledoc """
-  Live FX rate client backed by exchangerate.host (free, no key).
+  Live FX rate client backed by open.er-api.com (ExchangeRate-API open
+  endpoint, free, no key). Attribution is required by their terms and lives
+  in the analytics footnote.
 
-  The endpoint returns rates as "1 base = N target". We invert each pair so
-  we end up with "1 target = M base" (i.e. how many KRW for 1 USD).
+  The endpoint returns every rate as "1 base = N target" and ignores symbol
+  filters, so we take only the requested targets and invert each pair to
+  "1 target = M base" (i.e. how many KRW for 1 USD).
   """
 
   @behaviour AutoMyInvoice.FxRates.Client
 
-  @endpoint "https://api.exchangerate.host/latest"
+  @endpoint "https://open.er-api.com/v6/latest"
 
   @impl true
   def fetch_rates("KRW" = base, targets) do
-    case Req.get(@endpoint, params: [base: base, symbols: Enum.join(targets, ",")]) do
-      {:ok, %Req.Response{status: 200, body: %{"rates" => rates}}} ->
-        {:ok, invert_rates(rates)}
+    case Req.get("#{@endpoint}/#{base}", req_options()) do
+      {:ok, %Req.Response{status: 200, body: %{"result" => "success", "rates" => rates}}} ->
+        {:ok, rates |> Map.take(targets) |> invert_rates()}
+
+      {:ok, %Req.Response{status: 200, body: %{"result" => "error", "error-type" => type}}} ->
+        {:error, {:api_error, type}}
 
       {:ok, %Req.Response{status: status, body: body}} ->
         {:error, {:http_status, status, body}}
@@ -43,4 +49,9 @@ defmodule AutoMyInvoice.FxRates.HttpClient do
   defp decimal_from(n) when is_float(n), do: Decimal.from_float(n)
   defp decimal_from(n) when is_integer(n), do: Decimal.new(n)
   defp decimal_from(n) when is_binary(n), do: Decimal.new(n)
+
+  defp req_options do
+    Application.get_env(:auto_my_invoice, __MODULE__, [])
+    |> Keyword.get(:req_options, [])
+  end
 end

--- a/lib/auto_my_invoice_web/live/analytics_live.ex
+++ b/lib/auto_my_invoice_web/live/analytics_live.ex
@@ -124,6 +124,9 @@ defmodule AutoMyInvoiceWeb.AnalyticsLive do
 
       <p :if={@currency_breakdown.multi_currency?} class="text-xs text-base-content/40 mt-3">
         환율은 최신 캐시된 KRW 기준 환율이며, 매일 자동 갱신됩니다.
+        <a href="https://www.exchangerate-api.com" target="_blank" rel="noopener" class="link">
+          Rates By Exchange Rate API
+        </a>
       </p>
     </div>
 

--- a/test/auto_my_invoice/fx_rates/http_client_test.exs
+++ b/test/auto_my_invoice/fx_rates/http_client_test.exs
@@ -1,0 +1,65 @@
+defmodule AutoMyInvoice.FxRates.HttpClientTest do
+  use ExUnit.Case, async: true
+
+  alias AutoMyInvoice.FxRates.HttpClient
+
+  setup do
+    Req.Test.stub(HttpClient, fn conn ->
+      send(self(), {:fx_request_path, conn.request_path})
+
+      Req.Test.json(conn, %{
+        "result" => "success",
+        "base_code" => "KRW",
+        "rates" => %{
+          "KRW" => 1,
+          "USD" => 0.0008,
+          "JPY" => 0.1,
+          "EUR" => 0.000625,
+          "GBP" => 0.0005,
+          "THB" => 0.021956
+        }
+      })
+    end)
+
+    :ok
+  end
+
+  describe "fetch_rates/2" do
+    test "requests the KRW base endpoint and inverts rates to currency→KRW" do
+      assert {:ok, rates} = HttpClient.fetch_rates("KRW", ~w(USD JPY EUR GBP))
+
+      assert_received {:fx_request_path, "/v6/latest/KRW"}
+      assert Decimal.eq?(rates["USD"], Decimal.new("1250"))
+      assert Decimal.eq?(rates["JPY"], Decimal.new("10"))
+      assert Decimal.eq?(rates["EUR"], Decimal.new("1600"))
+      assert Decimal.eq?(rates["GBP"], Decimal.new("2000"))
+    end
+
+    test "returns only the requested targets, never the KRW identity rate" do
+      assert {:ok, rates} = HttpClient.fetch_rates("KRW", ~w(USD JPY))
+
+      assert Map.keys(rates) |> Enum.sort() == ~w(JPY USD)
+      refute Map.has_key?(rates, "KRW")
+      refute Map.has_key?(rates, "THB")
+    end
+
+    test "surfaces the provider error-type on API-level errors" do
+      Req.Test.stub(HttpClient, fn conn ->
+        Req.Test.json(conn, %{"result" => "error", "error-type" => "unsupported-code"})
+      end)
+
+      assert {:error, {:api_error, "unsupported-code"}} =
+               HttpClient.fetch_rates("KRW", ~w(USD))
+    end
+
+    test "surfaces non-200 responses as http_status errors" do
+      Req.Test.stub(HttpClient, fn conn ->
+        conn
+        |> Plug.Conn.put_status(429)
+        |> Req.Test.json(%{"result" => "error", "error-type" => "quota-reached"})
+      end)
+
+      assert {:error, {:http_status, 429, _body}} = HttpClient.fetch_rates("KRW", ~w(USD))
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- exchangerate.host가 access_key를 요구하면서 6월부터 FxRateRefreshWorker가 매일 실패, 프로덕션이 2026-06-10 시드 고정 환율에 묶여 있던 문제 수정
- 키가 필요 없는 open.er-api.com(ExchangeRate-API open endpoint)으로 프로바이더 교체

## Changes
- `FxRates.HttpClient`: 엔드포인트를 `open.er-api.com/v6/latest/KRW`로 교체. open endpoint는 symbol 필터를 무시하므로 요청 타깃만 추려서 기존 KRW 역산 로직에 전달
- API 레벨 에러(`{"result":"error"}`)를 `{:api_error, type}`으로 구분해 반환
- Req 옵션을 config로 주입 가능하게 해 `Req.Test` 기반 단위 테스트 4건 추가 (파싱·역산·타깃 필터링·에러 2종)
- FX 크론을 18:00 UTC → 01:00 UTC로 이동 (프로바이더의 ~00:06 UTC 일일 갱신 직후)
- 분석 페이지 각주에 "Rates By Exchange Rate API" 출처 링크 추가 (무료 사용 조건)

## Test Plan
- [x] `make precommit` — 539 tests, 0 failures
- [x] 변경 파일 `mix credo --strict` — no issues
- [x] 라이브 API 응답 형태·정밀도 사전 검증 (KRW 베이스, 소수 6자리)
- [ ] 배포 후 프로덕션에서 `FxRates.refresh!()` 수동 실행으로 환율 갱신 확인

## Notes
- frankfurter(ECB)도 검토했으나 KRW 환율이 유효숫자 2자리(USD 0.00066)라 역산 오차가 커서 제외
- open endpoint는 일 1회 갱신·IP당 쿼터라 일일 크론 1회 호출에는 여유가 큼